### PR TITLE
Remove add pet after submit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,6 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
-
+gem 'aasm'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    aasm (5.3.0)
+      concurrent-ruby (~> 1.0)
     actioncable (5.2.8.1)
       actionpack (= 5.2.8.1)
       nio4r (~> 2.0)
@@ -224,6 +226,7 @@ PLATFORMS
   x86_64-darwin-19
 
 DEPENDENCIES
+  aasm
   bootsnap (>= 1.1.0)
   capybara
   coffee-rails (~> 4.2)

--- a/app/controllers/application_pets_controller.rb
+++ b/app/controllers/application_pets_controller.rb
@@ -1,8 +1,8 @@
 class ApplicationPetsController < ApplicationController
-  
+
   def create
     @application = Application.find(params[:id])
-    @pet = @application.pets.first
+    @pet = Pet.find(params[:pet_id])
     @pet_app = ApplicationPet.create!(application: @application, pet: @pet)
     redirect_to "/applications/#{@application.id}"
   end
@@ -10,6 +10,4 @@ class ApplicationPetsController < ApplicationController
   def application_pet_params
     params.permit(:application_id, :pet_id)
   end
-
-
 end

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -23,6 +23,7 @@ class ApplicationsController < ApplicationController
   def update
     application = Application.find(params[:id])
     if application.update(application_params)
+      application.submit!
       flash[:success] = "YOU DID IT!"
     else
       flash[:error] = "The following problems prevented us from saving your application:\n#{application.errors.full_messages.to_sentence}"
@@ -31,7 +32,7 @@ class ApplicationsController < ApplicationController
   end
 
   def application_params
-    params.permit(:id, :name, :street_address, :city, :state, :zip_code, :description)
+    params.permit(:id, :name, :street_address, :city, :state, :zip_code)
   end
 
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,9 +1,19 @@
 class Application < ApplicationRecord
+  include ::AASM
   has_many :application_pets
   has_many :pets, through: :application_pets
-  attribute :status, default: "In Progress"
-  validates_presence_of :name, :street_address, :city, :state, :zip_code, :description
+  validates_presence_of :name, :street_address, :city, :state, :zip_code
 
+  aasm column: :status do
+    state :in_progress, initial: true, display: 'In Progress'
+    state :pending, display: 'Pending'
+
+    event :submit do
+      transitions from: :in_progress, to: :pending
+    end
+  end
+
+  # TODO: make this a class (self) method and remove Pet.all so it can be chained
   def search_pet(name)
     Pet.all.where("name ILIKE ?", "%#{name}%")
   end

--- a/app/views/application/new.html.erb
+++ b/app/views/application/new.html.erb
@@ -23,9 +23,6 @@
   <p> <%= f.label :zip_code, "Zipcode" %> </p>
   <%= f.number_field :zip_code %>
 
-  <p> <%= f.label :description, "Description" %> </p>
-  <%= f.text_field :description %>
-  
   <br>
   <%= f.submit "Submit" %>
 <% end %>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -5,38 +5,36 @@
 <p>City: <%= @application.city %> </p>
 <p>State: <%= @application.state %> </p>
 <p>Zip code: <%= @application.zip_code %> </p>
-<p>Status: <%= @application.status %> </p>
+<p>Status: <%= @application.aasm.human_state %> </p>
 
+<section id="addPet">
+  <h2> Add a Pet to this Application </h2>
+  <%= form_with url: "/applications/#{@application.id}", method: :get, local: true do |f| %>
+    <%= f.label :search_pet %>
+    <%= f.text_field :search_pet %>
+    <%= f.submit "Search Pets By Name" %>
+  <% end %>
+
+  <% if @searched_pets.present? %>
+    <% @searched_pets.each do |pet| %>
+      <p> <%= pet.name %>  </p>
+      <%= form_with url: "/applications/#{@application.id}", method: :post, local: true do |f| %>
+        <%= f.hidden_field :pet_id, value: pet.id %>
+        <%= f.submit "Adopt This Pet" %>
+      <% end %>
+    <% end %>
+  <% end %>
+  <% @application.pets.each do |pet| %>
+    <p> <%= pet.name %> </p>
+  <% end %>
+</section>
+
+<section id="submitForm">
 <%= form_with url: "/applications/#{@application.id}", method: :patch, local: true do |f| %>
   <h3><%= f.label :description, "What Would Make You A Great Owner?" %></h3>
   <%= f.text_area :description, value: @application.description %>
-  <br />
+  <br/>
   <%= f.submit "Submit" %>
 <% end %>
-<% @application.pets.each do |pet| %>
-  <p> <%= pet.name %> </p>
-<% end %>
-
-
- <section id="addPet" > 
-
- <h2> Add a Pet to this Application </h2>
-
-
-<%= form_with url: "/applications/#{@application.id}", method: :get, local: true do |f| %>
-  <%= f.label :search_pet %>
-  <%= f.text_field :search_pet %>
-  <%= f.submit "Search Pets By Name" %>
-<% end %>
-
-<% if @searched_pets.present? %>
-  <% @searched_pets.each do |pet|%>
-    <p> <%= pet.name %>  </p>
-    <%= form_with url: "/applications/#{@application.id}", method: :post, local: true do |f| %>
-      <%f.submit "Adopt This Pet"%>
-      <% end %>
-  <% end %>
-<% end %>
- </section>
-
+</section>
 

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -7,35 +7,47 @@
 <p>Zip code: <%= @application.zip_code %> </p>
 <p>Status: <%= @application.aasm.human_state %> </p>
 
-<section id="addPet">
-  <h2> Add a Pet to this Application </h2>
-  <%= form_with url: "/applications/#{@application.id}", method: :get, local: true do |f| %>
-    <%= f.label :search_pet %>
-    <%= f.text_field :search_pet %>
-    <%= f.submit "Search Pets By Name" %>
-  <% end %>
+<% if @application.in_progress? %>
+  <section id="addPet">
+    <h2> Add a Pet to this Application </h2>
+    <%= form_with url: "/applications/#{@application.id}", method: :get, local: true do |f| %>
+      <%= f.label :search_pet %>
+      <%= f.text_field :search_pet %>
+      <%= f.submit "Search Pets By Name" %>
+    <% end %>
 
-  <% if @searched_pets.present? %>
-    <% @searched_pets.each do |pet| %>
-      <p> <%= pet.name %>  </p>
-      <%= form_with url: "/applications/#{@application.id}", method: :post, local: true do |f| %>
-        <%= f.hidden_field :pet_id, value: pet.id %>
-        <%= f.submit "Adopt This Pet" %>
+    <% if @searched_pets.present? %>
+      <% @searched_pets.each do |pet| %>
+        <p> <%= pet.name %>  </p>
+        <%= form_with url: "/applications/#{@application.id}", method: :post, local: true do |f| %>
+          <%= f.hidden_field :pet_id, value: pet.id %>
+          <%= f.submit "Adopt This Pet" %>
+        <% end %>
       <% end %>
     <% end %>
-  <% end %>
-  <% @application.pets.each do |pet| %>
-    <p> <%= pet.name %> </p>
-  <% end %>
-</section>
-
-<% if @application.pets.any? %>
-  <section id="submitForm">
-  <%= form_with url: "/applications/#{@application.id}", method: :patch, local: true do |f| %>
-    <h3><%= f.label :description, "What Would Make You A Great Owner?" %></h3>
-    <%= f.text_area :description, value: @application.description %>
-    <br/>
-    <%= f.submit "Submit"%>
-  <% end %>
+    <h3>Pets I Want To Adopt</h3>
+    <% @application.pets.each do |pet| %>
+      <p> <%= pet.name %> </p>
+    <% end %>
   </section>
+
+  <% if @application.pets.any? %>
+    <section id="submitForm">
+      <%= form_with url: "/applications/#{@application.id}", method: :patch, local: true do |f| %>
+        <h3><%= f.label :description, "What Would Make You A Great Owner?" %></h3>
+        <%= f.text_area :description, value: @application.description %>
+        <br/>
+        <%= f.submit "Submit"%>
+      <% end %>
+    </section>
+  <% end %>
+<% end %>
+
+<% if @application.pending? %>
+  <h5>Pets you've applied to adopt:</h5>
+  <ul>
+    <% @application.pets.each do |pet| %>
+      <li><%= pet.name %></li>
+    <% end %>
+  </ul>
 <% end %>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -29,12 +29,13 @@
   <% end %>
 </section>
 
-<section id="submitForm">
-<%= form_with url: "/applications/#{@application.id}", method: :patch, local: true do |f| %>
-  <h3><%= f.label :description, "What Would Make You A Great Owner?" %></h3>
-  <%= f.text_area :description, value: @application.description %>
-  <br/>
-  <%= f.submit "Submit" %>
+<% if @application.pets.any? %>
+  <section id="submitForm">
+  <%= form_with url: "/applications/#{@application.id}", method: :patch, local: true do |f| %>
+    <h3><%= f.label :description, "What Would Make You A Great Owner?" %></h3>
+    <%= f.text_area :description, value: @application.description %>
+    <br/>
+    <%= f.submit "Submit"%>
+  <% end %>
+  </section>
 <% end %>
-</section>
-

--- a/db/migrate/20220903205710_fix_application_statuses.rb
+++ b/db/migrate/20220903205710_fix_application_statuses.rb
@@ -1,0 +1,12 @@
+class FixApplicationStatuses < ActiveRecord::Migration[5.2]
+  def up
+    Application.where(status: nil).update_all(status: 'in_progress')
+    Application.where(status: 'In Progress').update_all(status: 'in_progress')
+    Application.where(status: 'Pending').update_all(status: 'pending')
+  end
+
+  def down
+    Application.where(status: 'in_progress').update_all(status: 'In Progress')
+    Application.where(status: 'pending').update_all(status: 'Pending')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_01_210306) do
+ActiveRecord::Schema.define(version: 2022_09_03_205710) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,8 +7,8 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 
 
-app_1 = Application.create!(name: "Carter Ball", street_address: "123 Easy Street", city: "Atlanta", state: "GA", zip_code: 30307, status: "In Progress")
-app_2 = Application.create!(name: "Mary Ballantyne", street_address: "888 EZ Lane", city: "Denver", state: "CO", zip_code: 12345, status: "Pending")
+app_1 = Application.create!(name: "Carter Ball", street_address: "123 Easy Street", city: "Atlanta", state: "GA", zip_code: 30307, status: "In Progress", description: "something")
+app_2 = Application.create!(name: "Mary Ballantyne", street_address: "888 EZ Lane", city: "Denver", state: "CO", zip_code: 12345, status: "Pending", description: "something")
 
 shelter_1 = Shelter.create!(name: 'Mystery Building', city: 'Irvine CA', foster_program: false, rank: 9)
 shelter_2 = Shelter.create!(name: 'Humane Society', city: 'Humboldt CA', foster_program: true, rank: 4)

--- a/spec/features/applications/create_spec.rb
+++ b/spec/features/applications/create_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe 'the application creation' do
       expect(find('form')).to have_content('City')
       expect(find('form')).to have_content('State')
       expect(find('form')).to have_content('Zipcode')
-      expect(find('form')).to have_content('Description')
     end
   end
 end
@@ -27,7 +26,6 @@ describe 'the application create' do
       fill_in 'City', with: "Atlanta"
       fill_in 'State', with: "GA"
       fill_in 'Zipcode', with: 30307
-      fill_in 'Description', with: "I want a pet"
 
       expect { click_on "Submit" }.to change { Application.count }.by(1)
 
@@ -49,7 +47,6 @@ describe 'the application create' do
         expect(page).to have_content("Error: City can't be blank")
         expect(page).to have_content("Error: State can't be blank")
         expect(page).to have_content("Error: Zip code can't be blank")
-        expect(page).to have_content("Error: Description can't be blank")
       end
     end
   end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'the application show' do
     expect(page).to have_content(@app_1.state)
     expect(page).to have_content(@app_1.zip_code)
     expect(page).to have_content(@app_1.description)
-    expect(page).to have_content(@app_1.status)
+    expect(page).to have_content("In Progress")
     expect(page).to have_content(@pet_1.name)
     
 
@@ -54,10 +54,13 @@ RSpec.describe 'the application show' do
         click_button("Search Pets By Name")
         
         click_on "Adopt This Pet"
+
+        expect(page).to have_content('Scooby')
     end
   end
 
   it 'shows the filled out application with pending status and the pets the user wants to adopt' do
+    within("#submitForm")
     visit "/applications/#{@app_1.id}"
     fill_in 'What Would Make You A Great Owner?', with: "#{@app_1.description}"
 

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -9,10 +9,11 @@ RSpec.describe 'the application show' do
     @pet_1 = @shelter_1.pets.create!(name: 'Scooby', age: 2, breed: 'Great Dane', adoptable: true)
     @pet_2 = @shelter_1.pets.create!(name: 'Gilbert', age: 4, breed: 'Mutt', adoptable: true)
     @pet_app_1 = ApplicationPet.create!(application: @app_1, pet: @pet_1)
-    visit "/applications/#{@app_1.id}"
   end
-  
+
   it "shows the application and all its attributes" do
+    visit "/applications/#{@app_1.id}"
+
     expect(page).to have_content(@app_1.name)
     expect(page).to have_content(@app_1.street_address)
     expect(page).to have_content(@app_1.city)
@@ -29,6 +30,8 @@ RSpec.describe 'the application show' do
 
   describe 'the Add A Pet To This Application section'
     it 'exists and has a form with a button to search a pet' do
+      visit "/applications/#{@app_1.id}"
+
       within("#addPet") do
         expect(page).to have_content('Add a Pet to this Application')
         expect(find('form')).to have_content('Search')
@@ -38,6 +41,8 @@ RSpec.describe 'the application show' do
     end
 
     it 'searches for a pet' do
+      visit "/applications/#{@app_1.id}"
+
       within("#addPet") do
         fill_in('Search', with: 'scoo')
         click_button("Search Pets By Name")
@@ -49,6 +54,8 @@ RSpec.describe 'the application show' do
     end
 
     it 'has a button Adopt this Pet that adds a pet to an application' do
+      visit "/applications/#{@app_1.id}"
+
       within("#addPet") do
         fill_in('Search', with: 'scoo')
         click_button("Search Pets By Name")
@@ -60,6 +67,8 @@ RSpec.describe 'the application show' do
   end
 
   it 'shows the filled out application with pending status and the pets the user wants to adopt' do
+    visit "/applications/#{@app_1.id}"
+
     within("#submitForm")
     visit "/applications/#{@app_1.id}"
     fill_in 'What Would Make You A Great Owner?', with: "#{@app_1.description}"
@@ -71,5 +80,12 @@ RSpec.describe 'the application show' do
     expect(current_path).to eq("/applications/#{@app_1.id}")
     expect(page).to have_content("#{@app_1.description}")
     expect(page).to have_content('Status: Pending')
+  end
+
+  it 'does not display a submit button if pets have not been added' do
+    visit "/applications/#{@app_2.id}"
+
+    expect(page).to_not have_content('What Would Make You A Great Owner?')
+    expect(page).to_not have_button('Submit')
   end
 end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -78,8 +78,8 @@ RSpec.describe 'the application show' do
     click_button 'Submit'
 
     expect(current_path).to eq("/applications/#{@app_1.id}")
-    expect(page).to have_content("#{@app_1.description}")
     expect(page).to have_content('Status: Pending')
+    expect(page).to_not have_content('Search pet')
   end
 
   it 'does not display a submit button if pets have not been added' do

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Application, type: :model do
 
   describe "default attributes" do
     it 'defaults status to In Progress' do
-      expect(@app_1.status).to eq("In Progress")
+      expect(@app_1.status).to eq("in_progress")
     end
   end
 


### PR DESCRIPTION
Removed the ability to add a pet after the form has been submitted. User will be redirected to an application show page that now shows a list of the pets that have been requested and pending status. 