### PR TITLE
renamed status to app_status under applications table, and refactored tests to passing

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -23,7 +23,7 @@ class ApplicationsController < ApplicationController
   def update
     application = Application.find(params[:id])
     if application.update(application_params)
-      application.update(status: "Pending")
+      application.update(app_status: "Pending")
       flash[:success] = "YOU DID IT!"
     else
       flash[:error] = "The following problems prevented us from saving your application:\n#{application.errors.full_messages.to_sentence}"

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,7 +1,7 @@
 class Application < ApplicationRecord
   has_many :application_pets
   has_many :pets, through: :application_pets
-  attribute :status, default: "In Progress"
+  attribute :app_status, default: "In Progress"
   validates_presence_of :name, :street_address, :city, :state, :zip_code
 
   # aasm column: :status do

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -5,9 +5,9 @@
 <p>City: <%= @application.city %> </p>
 <p>State: <%= @application.state %> </p>
 <p>Zip code: <%= @application.zip_code %> </p>
-<p>Status: <%= @application.status %> </p>
+<p>Status: <%= @application.app_status %> </p>
 
-<% if @application.status == "In Progress" %>
+<% if @application.app_status == "In Progress" %>
   <section id="addPet">
     <h2> Add a Pet to this Application </h2>
     <%= form_with url: "/applications/#{@application.id}", method: :get, local: true do |f| %>
@@ -43,7 +43,7 @@
   <% end %>
 <% end %>
 
-<% if @application.status == "Pending" %>
+<% if @application.app_status == "Pending" %>
   <h5>Pets you've applied to adopt:</h5>
   <ul>
     <% @application.pets.each do |pet| %>

--- a/db/migrate/20220906195045_change_status_name_to_app_status.rb
+++ b/db/migrate/20220906195045_change_status_name_to_app_status.rb
@@ -1,0 +1,5 @@
+class ChangeStatusNameToAppStatus < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :applications, :status, :app_status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_03_205710) do
+ActiveRecord::Schema.define(version: 2022_09_06_195045) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 2022_09_03_205710) do
     t.string "state"
     t.integer "zip_code"
     t.string "description"
-    t.string "status"
+    t.string "app_status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe 'the admin application show page' do
   before :each do
     @shelter_1 = Shelter.create!(name: 'Mystery Building', city: 'Irvine CA', foster_program: false, rank: 9)
     @shelter_2 = Shelter.create!(name: 'Humane Society', city: 'Humboldt CA', foster_program: true, rank: 4)
-    @app_1 = Application.create!(name: "Carter Ball", street_address: "123 Easy Street", city: "Atlanta", state: "GA", zip_code: 30307, status: "Pending", description: "something")
-    @app_2 = Application.create!(name: "Mary Ballantyne", street_address: "888 EZ Lane", city: "Denver", state: "CO", zip_code: 12345, status: "Pending", description: "something")
+    @app_1 = Application.create!(name: "Carter Ball", street_address: "123 Easy Street", city: "Atlanta", state: "GA", zip_code: 30307, app_status: "Pending", description: "something")
+    @app_2 = Application.create!(name: "Mary Ballantyne", street_address: "888 EZ Lane", city: "Denver", state: "CO", zip_code: 12345, app_status: "Pending", description: "something")
     @pet_1 = @shelter_1.pets.create!(name: 'Scooby', age: 2, breed: 'Great Dane', adoptable: true)
     @pet_2 = @shelter_1.pets.create!(name: 'Fran', age: 4, breed: 'French Bulldog', adoptable: true)
     @pet_3 = @shelter_2.pets.create!(name: 'Gilbert', age: 4, breed: 'Mutt', adoptable: true)
@@ -25,7 +25,7 @@ RSpec.describe 'the admin application show page' do
 
   it 'shows an an approve button for that specific pet and when pressed changes status from pending to approved' do
     visit "/admin/applications/#{@app_1.id}"
-    expect(@pet_app_1.application.status).to eq("Pending")
+    expect(@pet_app_1.application.app_status).to eq("Pending")
     expect(page).to have_button("Approve")
     click_button "Approve"
 

--- a/spec/features/admin/shelters/index_spec.rb
+++ b/spec/features/admin/shelters/index_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe 'the admin shelters index page' do
   before :each do
     @shelter_1 = Shelter.create!(name: 'Mystery Building', city: 'Irvine CA', foster_program: false, rank: 9)
     @shelter_2 = Shelter.create!(name: 'Humane Society', city: 'Humboldt CA', foster_program: true, rank: 4)
-    @app_1 = Application.create!(name: "Carter Ball", street_address: "123 Easy Street", city: "Atlanta", state: "GA", zip_code: 30307, status: "Pending", description: "something")
-    @app_2 = Application.create!(name: "Mary Ballantyne", street_address: "888 EZ Lane", city: "Denver", state: "CO", zip_code: 12345, status: "Pending", description: "something")
+    @app_1 = Application.create!(name: "Carter Ball", street_address: "123 Easy Street", city: "Atlanta", state: "GA", zip_code: 30307, app_status: "Pending", description: "something")
+    @app_2 = Application.create!(name: "Mary Ballantyne", street_address: "888 EZ Lane", city: "Denver", state: "CO", zip_code: 12345, app_status: "Pending", description: "something")
     @pet_1 = @shelter_1.pets.create!(name: 'Scooby', age: 2, breed: 'Great Dane', adoptable: true)
     @pet_2 = @shelter_1.pets.create!(name: 'Fran', age: 4, breed: 'French Bulldog', adoptable: true)
     @pet_3 = @shelter_2.pets.create!(name: 'Gilbert', age: 4, breed: 'Mutt', adoptable: true)

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'the application show' do
     expect(page).to have_content(@app_1.state)
     expect(page).to have_content(@app_1.zip_code)
     expect(page).to have_content(@app_1.description)
-    expect(page).to have_content(@app_1.status) 
+    expect(page).to have_content(@app_1.app_status)
     expect(page).to have_content(@pet_1.name)
 
     expect(page).to_not have_content(@pet_2.name)

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Application, type: :model do
 
   describe "default attributes" do
     it 'defaults status to In Progress' do
-      expect(@app_1.status).to eq("In Progress")
+      expect(@app_1.app_status).to eq("In Progress")
     end
   end
 


### PR DESCRIPTION
Renamed the `status` column to `app_status` in applications table in order to prevent confusion from having two status columns in different tables. Tests have also been reformatted to reflect the change and all passing at this time.