### PR TITLE
update db status default and filter applications by status

### DIFF
--- a/app/controllers/admin/shelters_controller.rb
+++ b/app/controllers/admin/shelters_controller.rb
@@ -2,6 +2,7 @@ module Admin
   class SheltersController < ApplicationController
     def index
       @shelters = Shelter.find_by_sql("SELECT * FROM Shelters ORDER BY Name DESC")
+      @pending_shelters_filtered = Shelter.filter_by_pending_applications
     end
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -4,20 +4,6 @@ class Application < ApplicationRecord
   attribute :app_status, default: "In Progress"
   validates_presence_of :name, :street_address, :city, :state, :zip_code
 
-  # aasm column: :status do
-  #   state :in_progress, initial: true, display: 'In Progress'
-  #   state :pending, display: 'Pending'
-  #   state :approved, display: 'Approved'
-
-  #   event :submit do
-  #     transitions from: :in_progress, to: :pending
-  #   end
-
-  #   event :approve do
-  #     transitions from: :pending, to: :approved
-  #   end
-  # end
-
   # TODO: make this a class (self) method and remove Pet.all so it can be chained
   def search_pet(name)
     Pet.all.where("name ILIKE ?", "%#{name}%")

--- a/app/models/application_pet.rb
+++ b/app/models/application_pet.rb
@@ -1,6 +1,4 @@
 class ApplicationPet < ApplicationRecord
   belongs_to :application
   belongs_to :pet
-  attribute :status, default: "Pending"
-
 end

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -16,6 +16,14 @@ class Shelter < ApplicationRecord
       .order("pets_count DESC")
   end
 
+  def self.filter_by_pending_applications
+    joins("INNER JOIN pets ON pets.shelter_id = shelters.id")
+      .joins("INNER JOIN application_pets ON pets.id = application_pets.pet_id")
+      .where("application_pets.status": 'Pending')
+      .order(:name)
+      .distinct
+  end
+
   def pet_count
     pets.count
   end

--- a/app/views/admin/shelters/index.html.erb
+++ b/app/views/admin/shelters/index.html.erb
@@ -7,3 +7,10 @@
 <% end %>
   </section>
 </div>
+
+<div>
+  <section id="shelterappsPending">
+    <h3>Shelters with Pending Applications: </h3>
+    <p><%= @pending_shelters_filtered.map(&:name).join(', ') %></p>
+  </section>
+</div>

--- a/db/migrate/20220906210951_add_default_to_application_pet_status.rb
+++ b/db/migrate/20220906210951_add_default_to_application_pet_status.rb
@@ -1,0 +1,11 @@
+class AddDefaultToApplicationPetStatus < ActiveRecord::Migration[5.2]
+  def up
+    change_column_default :application_pets, :status, from: nil, to: 'Pending'
+    ApplicationPet.where(status: nil).update_all("status = 'Pending'")
+  end
+
+  def down
+    change_column_default :application_pets, :status, from: 'Pending', to: nil
+    ApplicationPet.where(status: 'Pending').update_all("status = NULL")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_06_195045) do
+ActiveRecord::Schema.define(version: 2022_09_06_210951) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2022_09_06_195045) do
   create_table "application_pets", force: :cascade do |t|
     t.bigint "application_id"
     t.bigint "pet_id"
-    t.string "status"
+    t.string "status", default: "Pending"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["application_id"], name: "index_application_pets_on_application_id"

--- a/spec/features/admin/shelters/index_spec.rb
+++ b/spec/features/admin/shelters/index_spec.rb
@@ -32,4 +32,12 @@ RSpec.describe 'the admin shelters index page' do
       expect(page).to have_content(@shelter_2.name)
     end
   end
+
+  it 'displays a section for shelters with pending applications' do
+    visit "/admin/shelters"
+
+    within("#shelterappsPending") do
+      expect(page).to have_content("Shelters with Pending Applications:\nHumane Society, Mystery Building")
+    end
+  end
 end

--- a/spec/models/shelter_spec.rb
+++ b/spec/models/shelter_spec.rb
@@ -67,5 +67,19 @@ RSpec.describe Shelter, type: :model do
         expect(@shelter_1.pet_count).to eq(3)
       end
     end
+
+    describe '.filter_by_pending_applications' do
+      before :each do
+        @pet_5 = @shelter_2.pets.create(name: 'Hannah', breed: 'Welsh Corgi', age: 4, adoptable: true)
+        @app_1 = Application.create!(name: 'Mary Ballantyne', street_address: "12 Mountain Ln", city: "Denver", state: "CO", zip_code: 801111)
+        @app_2 = Application.create!(name: 'Mackinley Smith', street_address: "123 Lake Rd", city: "Detroit", state: "MI", zip_code: 12345)
+        @pet_app_1 = ApplicationPet.create!(application_id: @app_1.id, pet_id: @pet_4.id, status: 'Pending')
+        @pet_app_2 = ApplicationPet.create!(application_id: @app_2.id, pet_id: @pet_5.id, status: 'Approved')
+      end
+      it 'filters the view showing only applications with pending status' do
+        filtered_apps = Shelter.filter_by_pending_applications
+        expect(filtered_apps.count).to eq(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
Made some minor adjustments to the database schema which changed the default for `status` in the application_pets table to 'Pending'. Previously the database was not saving any default information at all so this seems to have fixed that. I also made a feature that filters applications seen by the admin to only display pending applications, and created tests to display this as well in the models and admins/shelters/index_spec